### PR TITLE
fix Invalid read error

### DIFF
--- a/ips4o/cleanup_margins.hpp
+++ b/ips4o/cleanup_margins.hpp
@@ -78,7 +78,7 @@ std::pair<int, typename Cfg::difference_type> Sorter<Cfg>::saveMargins(int last_
     }
 
     // Read excess elements, if necessary
-    if (tail != end)
+    if (tail != end && begin_ + tail < end_)
         local_.swap[0].readFrom(begin_ + tail, end - tail);
 
     return {last_bucket, end - tail};


### PR DESCRIPTION
Don't read array beyond the given range [begin_, end_).
Avoid segmentation faults when reading from inaccessible memory.

valgrind output:
```
==12921== Invalid read of size 8
==12921==    at 0x1CA7D4: readFrom (new:169)
==12921==    by 0x1CA7D4: saveMargins (cleanup_margins.hpp:82)
==12921==    by 0x1CA7D4: std::pair<int, bool> ips4o::detail::Sorter<ips4o::ExtendedConfig<KMer<unsigned long>*, std::less<KMer<unsigned long> >, ips4o::Config<true, 16l, 16l, 2048l, long, 4096ul, 5l, 8, 4l, 20, 7>, ips4o::OpenMPThreadPool> >::partition<true>(KMer<unsigned long>*, KMer<unsigned long>*, long*, ips4o::detail::Sorter<ips4o::ExtendedConfig<KMer<unsigned long>*, std::less<KMer<unsigned long> >, ips4o::Config<true, 16l, 16l, 2048l, long, 4096ul, 5l, 8, 4l, 20, 7>, ips4o::OpenMPThreadPool> >::SharedData*, int, int) (partitioning.hpp:125)
==12921==    by 0x198A10: parallelSecondary (parallel.hpp:77)
==12921==    by 0x198A10: operator() (parallel.hpp:195)
==12921==    by 0x198A10: void ips4o::OpenMPThreadPool::operator()<ips4o::ParallelSorter<ips4o::ExtendedConfig<KMer<unsigned long>*, std::less<KMer<unsigned long> >, ips4o::Config<true, 16l, 16l, 2048l, long, 4096ul, 5l, 8, 4l, 20, 7>, ips4o::OpenMPThreadPool> >::operator()(KMer<unsigned long>*, KMer<unsigned long>*)::{lambda(int, int)#1}>(ips4o::ParallelSorter<ips4o::ExtendedConfig<KMer<unsigned long>*, std::less<KMer<unsigned long> >, ips4o::Config<true, 16l, 16l, 2048l, long, 4096ul, 5l, 8, 4l, 20, 7>, ips4o::OpenMPThreadPool> >::operator()(KMer<unsigned long>*, KMer<unsigned long>*)::{lambda(int, int)#1}&&, int) [clone ._omp_fn.1] (thread_pool.hpp:95)
==12921==    by 0x60DCABD: gomp_thread_start (team.c:120)
==12921==    by 0x6117A9C: start_thread (in /usr/lib/libpthread-2.28.so)
==12921==    by 0x622CA42: clone (in /usr/lib/libc-2.28.so)
==12921==  Address 0x2dbe55a8 is 0 bytes after a block of size 4,490,600 alloc'd
==12921==    at 0x483777F: malloc (vg_replace_malloc.c:299)
==12921==    by 0x1D5512: D_allocate (FBVector.h:116)
==12921==    by 0x1D5512: M_allocate (FBVector.h:236)
==12921==    by 0x1D5512: reserve (FBVector.h:985)
```